### PR TITLE
Update Action Runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ jobs:
         uses: actions/checkout@master
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@master
-        with: 
-          additional_files: 'gh-get-repos'
+        with:
+          additional_files: "gh-get-repos"
         env:
           SHELLCHECK_OPTS: -e SC1091 -e SC2155
   verify-extension:
@@ -26,12 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
-          - ubuntu-18.04
           - macos-11
-          - macos-10.15
-          - windows-2022
+          - macos-12
+          - ubuntu-20.04
+          - ubuntu-22.04
           - windows-2019
+          - windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@master


### PR DESCRIPTION
A few updates have occurred to the list of platforms that GitHub Actions supports, so this needs to be updated to incorporate these latest changes.

### Desired Outcome
Changes to the project will be tested on all supported platforms/versions that GitHub supports:
- Add `macos-12`
- Add `ubuntu-22.04`
- Remove `macos-10.15`
- Remove `ubuntu-18.04`
